### PR TITLE
added usage of username to support more routers

### DIFF
--- a/tplink/tplink.py
+++ b/tplink/tplink.py
@@ -11,7 +11,7 @@ class TpLinkClient(object):
     def __init__(self, password, host='192.168.1.1', username=None):
         self.host = host
         self.password = password
-
+        self.username = username
         self.parse_macs = re.compile(
             'MACAddress=([0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:' +
             '[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2})')
@@ -19,8 +19,11 @@ class TpLinkClient(object):
         self.parse_names = re.compile('hostName=(.*)')
 
     def get_connected_devices(self):
+        connection_string = self.password
+        if self.username is not None:
+            connection_string = '{}:{}'.format(self.username, self.password)
         b64_encoded_password = base64.b64encode(
-            self.password.encode('ascii')).decode('ascii')
+            connection_string.encode('ascii')).decode('ascii')
         cookie = 'Authorization=Basic {}' \
             .format(b64_encoded_password)
 


### PR DESCRIPTION
Tested on archer c3200
this fix make usage of the username param to connect to more router models