### PR TITLE
Add Omada Controller support

### DIFF
--- a/tplink/cli.py
+++ b/tplink/cli.py
@@ -16,7 +16,7 @@ from tplink import tplink
     '--username', default=None, help='The administrator account username')
 def main(host, password, username):
     """Console script for tplink."""
-    client = tplink.TpLinkClient(password)
+    client = tplink.TpLinkClient(password, host=host, username=username)
     devices = client.get_connected_devices()
     click.echo(json.dumps(devices, indent=4))
     return 0

--- a/tplink/tplink.py
+++ b/tplink/tplink.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """Main module."""
 import base64
+import json
 import re
+from urllib.parse import urlparse
 
 import requests
 from aiohttp.hdrs import (CONTENT_TYPE, COOKIE, REFERER)
@@ -12,13 +14,81 @@ class TpLinkClient(object):
         self.host = host
         self.password = password
         self.username = username
+        self.ssl_verify = False
         self.parse_macs = re.compile(
             'MACAddress=([0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:' +
             '[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2})')
 
         self.parse_names = re.compile('hostName=(.*)')
 
+        self.is_omada_controller = False
+        self._detect_omada()
+
+    def _detect_omada(self):
+        base_url = urlparse(self.host)
+        if not base_url.netloc:
+            return
+        base_url = base_url.scheme + "://" + base_url.netloc
+        res = requests.get(base_url, allow_redirects=False)
+        if 'TPEAP_SESSIONID' not in res.cookies:
+            return
+        # This seams to be an Omada controller
+        self.is_omada_controller = True
+
+    def _get_connected_devices_omada(self):
+        login_path = "/api/user/login?ajax"
+        clients_path = "/web/v1/controller?userStore&token="
+        current_page_size = 10
+
+        requests.packages.urllib3.disable_warnings()
+        session = requests.Session()
+        # Get SessionID
+        # host variable should includes scheme and port (if not standard)
+        # ie https://192.168.1.2:8043
+        res = session.get(self.host, verify=self.ssl_verify)
+        # Get actual URL
+        actual_location = urlparse(res.history[-1].headers['location'])
+        base_url = actual_location.scheme + "://" + actual_location.netloc
+        # Login
+        login_data = {"method": "login",
+                      "params": {"name": self.username,
+                                 "password": self.password
+                                 }
+                      }
+        res = session.post(base_url + login_path,
+                           data=json.dumps(login_data),
+                           verify=self.ssl_verify)
+        if res.json().get('msg') != 'Log in successfully.':
+            raise Exception("AP didn't respond with JSON. "
+                            "Check if credentials are correct")
+        # Get token
+        token = res.json()['result']['token']
+        current_page = 1
+        total_rows = current_page_size + 1
+        list_of_devices = {}
+        while current_page * current_page_size <= total_rows:
+            clients_data = {"method": "getGridActiveClients",
+                            "params": {"sortOrder": "asc",
+                                       "currentPage": current_page,
+                                       "currentPageSize": current_page_size,
+                                       "filters": {"type": "all"}
+                                       }
+                            }
+            res = session.post(base_url + clients_path + token,
+                               data=json.dumps(clients_data),
+                               verify=self.ssl_verify)
+            results = res.json()['result']
+            total_rows = results['totalRows']
+            list_of_devices.update({data['mac'].replace('-', ':'): data['name']
+                                    for data in results['data']})
+            current_page += 1
+
+        return list_of_devices
+
     def get_connected_devices(self):
+        if self.is_omada_controller:
+            return self._get_connected_devices_omada()
+
         connection_string = self.password
         if self.username is not None:
             connection_string = '{}:{}'.format(self.username, self.password)

--- a/tplink/tplink.py
+++ b/tplink/tplink.py
@@ -30,7 +30,8 @@ class TpLinkClient(object):
         if not base_url.netloc:
             return
         base_url = base_url.scheme + "://" + base_url.netloc
-        res = requests.get(base_url, allow_redirects=False)
+        requests.packages.urllib3.disable_warnings()
+        res = requests.get(base_url, allow_redirects=False, verify=self.ssl_verify)
         if 'TPEAP_SESSIONID' not in res.cookies:
             return
         # This seams to be an Omada controller
@@ -41,7 +42,6 @@ class TpLinkClient(object):
         clients_path = "/web/v1/controller?userStore&token="
         current_page_size = 10
 
-        requests.packages.urllib3.disable_warnings()
         session = requests.Session()
         # Get SessionID
         # host variable should includes scheme and port (if not standard)


### PR DESCRIPTION
This patch adds support for Omada controller version 3.1.4.
I guess it can work with other versions but I didn't tested.
Also, with this patch, the lib tries to detect if the device is an Omada Controller or not. So nothing change for users.

Example: 
```
tplink PASSWORD --host http://192.168.1.1:8088 --username USERNAME
```
Answer
```
{
    "AA:BB:CC:EE:FF:00": "device1",
    "AA:BB:CC:EE:FF:01": "device2"
}
```